### PR TITLE
Add `navbar` field to PageNode

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DocumenterPages"
 uuid = "3b6f6c89-491e-49ab-a70c-af796c43d097"
 authors = ["Anshul Singhvi <anshulsinghvi@gmail.com> and contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/ext/DocumenterPagesDocumenterVitepressExt.jl
+++ b/ext/DocumenterPagesDocumenterVitepressExt.jl
@@ -35,7 +35,9 @@ function DocumenterVitepress.pagelist2str(doc, node::PageNode, sidenav::Val{:sid
 end
 
 # Navbar: prefer a direct link; otherwise a dropdown of children; else plain text.
+# `navbar === false` drops the node (the :sidebar method above doesn't check it).
 function DocumenterVitepress.pagelist2str(doc, node::PageNode, sidenav::Val{:navbar})
+    node.navbar === false && return ""
     name = _esc(_title(doc, node))
     if !isnothing(node.page)
         return "text: '$(name)', link: '$(_link(node.page))'"

--- a/src/pagenode.jl
+++ b/src/pagenode.jl
@@ -1,6 +1,6 @@
 """
-    PageNode(input; visible, collapsed)
-    PageNode(this_page, children; visible, collapsed)
+    PageNode(input; visible, collapsed, navbar)
+    PageNode(this_page, children; visible, collapsed, navbar)
 
 Creates a `PageNode` object, which may have some children.
 
@@ -8,6 +8,10 @@ Creates a `PageNode` object, which may have some children.
 for example a string, a pair of strings, a vector of strings or pairs, or any combination thereof.
 
 You can also specify details for the toplevel page and its children separately in the two-argument constructor.
+
+`navbar = false` hides this node from a writer's top-level navbar (e.g. DocumenterVitepress)
+while keeping it in the sidebar. `visible = false` hides it everywhere, since it goes
+through Documenter's own `NavNode` machinery.
 
 ## Examples
 
@@ -32,27 +36,28 @@ struct PageNode
     title_override::Union{String, Nothing}
     visible::Union{Bool, Nothing}
     collapsed::Union{Bool, Nothing} # nothing here indicates that we follow the global spec
+    navbar::Union{Bool, Nothing} # false hides this node from a top-level navbar; nothing means shown
 end
 
 # TODO: kwarg constructor, setfield constructor,
 
 PageNode(input::Pair; kw...) = PageNode(input[1], input[2]; kw...)
-PageNode(input::String; visible = nothing, collapsed = nothing) = PageNode(input, PageNode[], nothing, visible, collapsed)
-PageNode(title::String, source::String; visible = nothing, collapsed = nothing) = PageNode(source, PageNode[], title, visible, collapsed)
+PageNode(input::String; visible = nothing, collapsed = nothing, navbar = nothing) = PageNode(input, PageNode[], nothing, visible, collapsed, navbar)
+PageNode(title::String, source::String; visible = nothing, collapsed = nothing, navbar = nothing) = PageNode(source, PageNode[], title, visible, collapsed, navbar)
 PageNode(pn::PageNode) = pn
 
-function PageNode(input::Vector; visible = nothing, collapsed = nothing, kw...)
+function PageNode(input::Vector; visible = nothing, collapsed = nothing, navbar = nothing, kw...)
 
 	children = PageNode.(input; kw...)
-	return PageNode(nothing, children, nothing, visible, collapsed)
+	return PageNode(nothing, children, nothing, visible, collapsed, navbar)
 
 end
 
-function PageNode(titlechildren::Pair{String, Vector}; visible = nothing, collapsed = nothing, kw...)
+function PageNode(titlechildren::Pair{String, Vector}; visible = nothing, collapsed = nothing, navbar = nothing, kw...)
 
 	children = PageNode.(titlechildren[2]; kw...)
 
-	return PageNode(nothing, children, titlechildren[1], visible, collapsed)
+	return PageNode(nothing, children, titlechildren[1], visible, collapsed, navbar)
 end
 
 function PageNode(original_page, children::Vector; kw...)
@@ -60,7 +65,7 @@ function PageNode(original_page, children::Vector; kw...)
 
 	@assert isempty(pn1.children) "You can't specify multiple children!  Look at the type of the first argument to this function."
 
-	return PageNode(pn1.page, PageNode.(children; kw...), pn1.title_override, pn1.visible, pn1.collapsed)
+	return PageNode(pn1.page, PageNode.(children; kw...), pn1.title_override, pn1.visible, pn1.collapsed, pn1.navbar)
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,13 @@ using Test
         pn4 = PageNode("test.md", visible=false, collapsed=true)
         @test pn4.visible === false
         @test pn4.collapsed === true
+
+        # `navbar` defaults to unset, and can be set independently of `visible`.
+        pn5 = PageNode("test.md")
+        @test isnothing(pn5.navbar)
+        pn6 = PageNode("test.md"; navbar=false)
+        @test pn6.navbar === false
+        @test isnothing(pn6.visible) # unaffected by `navbar`
     end
 
     @testset "AbstractTrees interface" begin
@@ -82,10 +89,10 @@ using Test
         @test occursin("link: '/tutorials/datasets/index'", side)
 
         # Navbar: prefers the direct link over a dropdown.
-        nav = DocumenterVitepress.pagelist2str(nothing, node, Val(:navbar))
-        @test occursin("text: 'Platform Features'", nav)
-        @test occursin("link: '/tutorials/index'", nav)
-        @test !occursin("items:", nav)
+        navbar_str = DocumenterVitepress.pagelist2str(nothing, node, Val(:navbar))
+        @test occursin("text: 'Platform Features'", navbar_str)
+        @test occursin("link: '/tutorials/index'", navbar_str)
+        @test !occursin("items:", navbar_str)
 
         # A childless PageNode is a plain leaf link.
         leaf = PageNode("Solo" => "solo.md")
@@ -96,6 +103,13 @@ using Test
         cs = DocumenterVitepress.pagelist2str(nothing, collapsed_node, Val(:sidebar))
         @test occursin("collapsed: true", cs)
         @test occursin("text: 'What\\'s New'", cs)
+
+        # navbar=false hides a node from the navbar only; the sidebar is unaffected.
+        hidden_node = PageNode("Releases" => "releases.md"; navbar=false)
+        @test DocumenterVitepress.pagelist2str(nothing, hidden_node, Val(:navbar)) == ""
+        sidebar_str = DocumenterVitepress.pagelist2str(nothing, hidden_node, Val(:sidebar))
+        @test occursin("text: 'Releases'", sidebar_str)
+        @test occursin("link: '/releases'", sidebar_str)
     end
 
 end


### PR DESCRIPTION
## Summary
- `PageNode` gains a `navbar::Union{Bool,Nothing}` field, parallel to the existing `visible`/`collapsed` metadata.
- `navbar = false` hides a node from a writer's top-level navbar (e.g. DocumenterVitepress) while leaving it in the sidebar — this is narrower than `visible`, which (via Documenter's own `NavNode` machinery) hides a page from navigation everywhere.
- Wires the new field into `DocumenterPagesDocumenterVitepressExt`'s `:navbar` rendering method; the `:sidebar` method is untouched.
- Bumps patch version to 0.1.3.

Motivated by [help.juliahub.com](https://github.com/JuliaComputing/help.juliahub.com)'s docs nav overflowing with 10 top-level entries — several pages needed to stay in the sidebar but drop out of the navbar.

## Test plan
- [x] New unit tests for `navbar` field construction/defaults
- [x] New unit tests for `:navbar` vs `:sidebar` rendering of a `navbar=false` node
- [x] Full existing suite still passes (43/43)